### PR TITLE
[refactor]: Limit Display to Three Content Blocks on Small Screens

### DIFF
--- a/components/problem-blocks.tsx
+++ b/components/problem-blocks.tsx
@@ -3,8 +3,8 @@ export default function ProblemBlocks() {
     <section className="relative">
 
       {/* Section background (needs .relative class on parent and next sibling elements) */}
-      <div className="absolute inset-0 top-1/2 md:mt-24 lg:mt-0 bg-gradient-to-b from-secondary-500 to-secondary-100  pointer-events-none" aria-hidden="true"/>
-      <div className="absolute left-0 right-0 bottom-0 m-auto w-px p-px h-20 bg-gray-200 transform translate-y-1/2"/>
+      <div className="absolute inset-0 top-1/2 md:mt-24 lg:mt-0 bg-gradient-to-b from-secondary-500 to-secondary-100  pointer-events-none" aria-hidden="true" />
+      <div className="absolute left-0 right-0 bottom-0 m-auto w-px p-px h-20 bg-gray-200 transform translate-y-1/2" />
 
       <div className="relative max-w-6xl mx-auto px-4 sm:px-6">
         <div className="py-12 md:py-20">
@@ -36,7 +36,7 @@ export default function ProblemBlocks() {
           <div className="max-w-sm mx-auto grid gap-6 md:grid-cols-2 lg:grid-cols-3 items-start md:max-w-2xl lg:max-w-none ">
 
             {/* 1st item */}
-            <div className="relative flex flex-col items-center p-6 bg-white rounded shadow-xl">
+            <div className="hidden md:flex relative  flex-col items-center p-6 bg-white rounded shadow-xl">
               <svg className="w-16 h-16 p-1 -mt-1 mb-2" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
                 <g fill="none" fillRule="evenodd">
                   <rect className="fill-current text-primary-300" width="64" height="64" rx="32" />
@@ -44,7 +44,7 @@ export default function ProblemBlocks() {
                     <path className="stroke-current text-secondary-300" d="M34.514 35.429l2.057 2.285h8M20.571 26.286h5.715l2.057 2.285" />
                     <path className="stroke-current text-primary-500" d="M20.571 37.714h5.715L36.57 26.286h8" />
                     <path className="stroke-current text-secondary-300" strokeLinecap="square" d="M41.143 34.286l3.428 3.428-3.428 3.429" />
-                    <path className="stroke-current text-primary-500" strokeLinecap="square" d="M41.143 29.714l3.428-3.428-3.428-3.429" />  
+                    <path className="stroke-current text-primary-500" strokeLinecap="square" d="M41.143 29.714l3.428-3.428-3.428-3.429" />
                   </g>
                 </g>
               </svg>
@@ -69,7 +69,7 @@ export default function ProblemBlocks() {
             </div>
 
             {/* 3rd item */}
-            <div className="relative flex flex-col items-center p-6 bg-white rounded shadow-xl">
+            <div className="hidden relative md:flex flex-col items-center p-6 bg-white rounded shadow-xl">
               <svg className="w-16 h-16 p-1 -mt-1 mb-2" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
                 <g fill="none" fillRule="evenodd">
                   <rect className="fill-current text-primary-300" width="64" height="64" rx="32" />
@@ -103,7 +103,7 @@ export default function ProblemBlocks() {
             </div>
 
             {/* 5th item */}
-            <div className="relative flex flex-col items-center p-6 bg-white rounded shadow-xl">
+            <div className="hidden relative md:flex flex-col items-center p-6 bg-white rounded shadow-xl">
               <svg className="w-16 h-16 p-1 -mt-1 mb-2" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
                 <g fill="none" fillRule="evenodd">
                   <rect className="fill-current text-primary-300" width="64" height="64" rx="32" />


### PR DESCRIPTION
Fixes issue: [#1772](https://github.com/keploy/keploy/issues/1772)

Changes:

- Display is limited to only three problem blocks, namely Manual test writing, Dependency chaos, and Scattered test environments

![image](https://github.com/keploy/website/assets/98450585/24163675-01b8-4d8b-9f36-0ab59b4e5436)
