### PR TITLE
fix: import of community.css

### DIFF
--- a/components/community.tsx
+++ b/components/community.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import "../app/css/community.css";
+import "./community.css";
 import Image from "next/image";
 import CommunityBunny from "@/public/images/community-bunny.png";
 import GithubSvg from "@/public/images/social/github.svg";


### PR DESCRIPTION
Due to incorrect import of community.css the community section is breaking 
![Screenshot from 2024-04-17 11-17-46](https://github.com/keploy/website/assets/78696767/02be70cd-f0c1-46a5-ab84-bab2cba4d7f7)
