### PR TITLE
Fixes the explore more button

### DIFF
--- a/components/FeatureMoblieView.tsx
+++ b/components/FeatureMoblieView.tsx
@@ -98,7 +98,7 @@ export default function FeaturesMobileView() {
                   </div>
                     </div>
                     <div>
-                      <Link className="btn mt-4 text-secondary-300 bg-primary-300 hover:text-white w-full mb-4 sm:w-auto sm:mb-0" href="/stub-generation">Explore More</Link>
+                      <Link className="btn mt-4 text-secondary-300 bg-primary-300 hover:text-white w-full mb-4 sm:w-auto sm:mb-0" href="/docs/server/sdk-installation/go">Explore More</Link>
                     </div>
                   </div>
 
@@ -141,7 +141,7 @@ export default function FeaturesMobileView() {
                     </div>
                     </div>
                     <div>
-                      <Link className="btn mt-4 text-secondary-300 bg-primary-300 hover:text-white w-full mb-4 sm:w-auto sm:mb-0" href="/test-duplication">Explore More</Link>
+                      <Link className="btn mt-4 text-secondary-300 bg-primary-300 hover:text-white w-full mb-4 sm:w-auto sm:mb-0" href="/docs/server/sdk-installation/go">Explore More</Link>
                     </div>
                 </div>
                 </Link>
@@ -182,7 +182,7 @@ export default function FeaturesMobileView() {
                   </div>
                   </div>
                   <div>
-                      <Link className="btn mt-4 text-secondary-300 bg-primary-300 hover:text-white w-full mb-4 sm:w-auto sm:mb-0" href="/native-integration">Explore More</Link>
+                      <Link className="btn mt-4 text-secondary-300 bg-primary-300 hover:text-white w-full mb-4 sm:w-auto sm:mb-0" href="/docs/server/sdk-installation/go">Explore More</Link>
                   </div>
                 </div>
                 </Link>

--- a/components/features.tsx
+++ b/components/features.tsx
@@ -172,7 +172,7 @@ useGSAP(
                 heading={"Record Replay API Flows"}
                 description=" Record and replay complex, distributed API flows as mocks and stubs. It's like time machine for tests!"
                 btnDescription="Explore More"
-                btnLink="/stub-generation"
+                btnLink="/docs/server/sdk-installation/go/"
               />
             </div>
             <div className="flex items-center detail">
@@ -192,7 +192,7 @@ useGSAP(
                 heading={"Find Duplicate Tests"}
                 description="Find redundant tests that doesn't add to the test coverage. Automatically detect and remove duplicate tests, ideal for big-teams crowd-sourcing tests."
                 btnDescription="Explore More"
-                btnLink="/test-duplication"
+                btnLink="/docs/server/sdk-installation/go"
               />
             </div>
             <div className="flex items-center detail">
@@ -212,7 +212,7 @@ useGSAP(
                 heading={"Works with JUnit, PyTest, Jest, Go-Test in CI/CD"}
                 description="Merge Keploy tests coverage with unit testing libraries for combined test coverage gating in CI/CD pipelines like Jenkins, Github Actions."
                 btnDescription="Explore More"
-                btnLink="/native-integration"
+                btnLink="/docs/server/sdk-installation/go/"
               />
             </div>
           </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10157,7 +10157,6 @@
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
       "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
All of the following buttons used to show 404 message according to issue #2074 in the main repo. FIxed all the buttons and added  https://keploy.io/docs/server/sdk-installation/go/ this link as suggested.

Record Replay API Flows
Record and replay complex, distributed API flows as mocks and stubs. It's like time machine for tests!

Find Duplicate Tests
Find redundant tests that doesn't add to the test coverage. Automatically detect and remove duplicate tests, ideal for big-teams crowd-sourcing tests.

Works with JUnit, PyTest, Jest, Go-Test in CI/CD

Explore more -> https://keploy.io/docs/server/sdk-installation/go/