### PR TITLE
Language icons on home page point to their respective samples page

### DIFF
--- a/components/language.tsx
+++ b/components/language.tsx
@@ -526,7 +526,7 @@ export default function Language() {
           {/* Items */}
           <div className="grid max-w-sm grid-cols-6 gap-4 mx-auto md:max-w-4xl md:grid-cols-6 place-content-center">
             {/* Item */}
-            <div className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
+            <a href="https://keploy.io/docs/quickstart/samples-java/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
               <svg
                 className="max-w-full"
                 xmlns="http://www.w3.org/2000/svg"
@@ -547,10 +547,10 @@ export default function Language() {
                   fill="#4e7896"
                 />
               </svg>
-            </div>
+            </a>
 
             {/* Item */}
-            <div className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
+            <a href="https://keploy.io/docs/quickstart/samples-nodejs/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 className="max-w-full"
@@ -574,10 +574,10 @@ export default function Language() {
                   />
                 </g>
               </svg>
-            </div>
+            </a>
 
             {/* Item */}
-            <div className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
+            <a href="https://keploy.io/docs/quickstart/samples-gin/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
               <svg
                 className="max-w-full "
                 xmlns="http://www.w3.org/2000/svg"
@@ -592,10 +592,10 @@ export default function Language() {
                   d="M40.2,101.1c-.4,0-.5-.2-.3-.5l2.1-2.7c.2-.3.7-.5,1.1-.5l35.7,0c.4,0,.5,.3,.3,.6l-1.7,2.6c-.2,.3-.7,.6-1,.6L40.2,101.1z M25.1,110.3c-.4,0-.5-.2-.3-.5l2.1-2.7c.2-.3.7-.5,1.1-.5l45.6,0c.4,0,.6,.3,.5,.6l-.8,2.4c-.1,.4-.5,.6-.9,.6L25.1,110.3z M49.3,119.5c-.4,0-.5-.3-.3-.6l1.4-2.5c.2-.3,.6-.6,1-.6l20,0c.4,0,.6,.3,.6,.7l-.2,2.4c0,.4-.4,.7-.7,.7L49.3,119.5z M153.1,99.3c-6.3,1.6-10.6,2.8-16.8,4.4c-1.5,.4-1.6,.5-2.9-1c-1.5-1.7-2.6-2.8-4.7-3.8c-6.3-3.1-12.4-2.2-18.1,1.5c-6.8,4.4-10.3,10.9-10.2,19c.1,8,5.6,14.6,13.5,15.7c6.8,.9,12.5-1.5,17-6.6c.9-1.1,1.7-2.3,2.7-3.7c-3.6,0-8.1,0-19.3,0c-2.1,0-2.6-1.3-1.9-3c1.3-3.1,3.7-8.3,5.1-10.9c.3-.6,1-1.6,2.5-1.6c5.1,0,23.9,0,36.4,0c-.2,2.7-.2,5.4-.6,8.1c-1.1,7.2-3.8,13.8-8.2,19.6c-7.2,9.5-16.6,15.4-28.5,17c-9.8,1.3-18.9-.6-26.9-6.6c-7.4-5.6-11.6-13-12.7-22.2c-1.3-10.9,1.9-20.7,8.5-29.3c7.1-9.3,16.5-15.2,28-17.3c9.4-1.7,18.4-.6,26.5,4.9c5.3,3.5,9.1,8.3,11.6,14.1c.6,.9.2,1.4-1,1.7zM186.2,154.6c-9.1-.2-17.4-2.8-24.4-8.8c-5.9-5.1-9.6-11.6-10.8-19.3c-1.8-11.3,1.3-21.3,8.1-30.2c7.3-9.6,16.1-14.6,28-16.7c10.2-1.8,19.8-.8,28.5,5.1c7.9,5.4,12.8,12.7,14.1,22.3c1.7,13.5-2.2,24.5-11.5,33.9c-6.6,6.7-14.7,10.9-24,12.8c-2.7,.5-5.4,.6-8,.9zm23.8-40.4c-.1-1.3-.1-2.3-.3-3.3c-1.8-9.9-10.9-15.5-20.4-13.3c-9.3,2.1-15.3,8-17.5,17.4c-1.8,7.8,2,15.7,9.2,18.9c5.5,2.4,11,2.1,16.3-.6c7.9-4.1,12.2-10.5,12.7-19.1z"
                 />
               </svg>
-            </div>
+            </a>
 
             {/* Item */}
-            <div className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
+            <a href="https://keploy.io/docs/quickstart/samples-django/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="200"
@@ -659,8 +659,10 @@ export default function Language() {
                   fill="url(#c)"
                 />
               </svg>
-            </div>
-            <div className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
+            </a>
+
+            {/* Item */}
+            <a href="https://keploy.io/docs/quickstart/samples-csharp/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
               <Image
                 src="/images/frameworks/csharp.svg"
                 alt="C# Logo"
@@ -668,8 +670,10 @@ export default function Language() {
                 height={80}
                 className="mb-2"
               />
-            </div>
-            <div className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
+            </a>
+
+            {/* Item */}
+            <a href="https://keploy.io/docs/quickstart/samples-rust/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
               <Image
                 src="/images/frameworks/rust.svg"
                 alt="C# Logo"
@@ -677,7 +681,7 @@ export default function Language() {
                 height={80}
                 className="mb-5"
               />
-            </div>
+            </a>
           </div>
           {/* Testimonials */}
           {/* <div className="max-w-3xl mx-auto mt-20 " data-aos="zoom-y-out">

--- a/components/language.tsx
+++ b/components/language.tsx
@@ -1,6 +1,7 @@
 import TestimonialImage from "@/public/images/users/Nutanix_Logo.svg";
 import React, { useState, useEffect } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import ApacheClient from "@/public/images/frameworks/apacheclient.png";
 import Chi from "@/public/images/frameworks/chi.png";
 import Dynamo from "@/public/images/frameworks/dynamo.png";
@@ -526,7 +527,7 @@ export default function Language() {
           {/* Items */}
           <div className="grid max-w-sm grid-cols-6 gap-4 mx-auto md:max-w-4xl md:grid-cols-6 place-content-center">
             {/* Item */}
-            <a href="https://keploy.io/docs/quickstart/samples-java/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
+            <Link href="https://keploy.io/docs/quickstart/pet-clinic/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
               <svg
                 className="max-w-full"
                 xmlns="http://www.w3.org/2000/svg"
@@ -547,10 +548,10 @@ export default function Language() {
                   fill="#4e7896"
                 />
               </svg>
-            </a>
+            </Link>
 
             {/* Item */}
-            <a href="https://keploy.io/docs/quickstart/samples-nodejs/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
+            <Link href="https://keploy.io/docs/quickstart/samples-nodejs/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 className="max-w-full"
@@ -574,10 +575,10 @@ export default function Language() {
                   />
                 </g>
               </svg>
-            </a>
+            </Link>
 
             {/* Item */}
-            <a href="https://keploy.io/docs/quickstart/samples-gin/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
+            <Link href="https://keploy.io/docs/quickstart/samples-gin/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
               <svg
                 className="max-w-full "
                 xmlns="http://www.w3.org/2000/svg"
@@ -592,10 +593,10 @@ export default function Language() {
                   d="M40.2,101.1c-.4,0-.5-.2-.3-.5l2.1-2.7c.2-.3.7-.5,1.1-.5l35.7,0c.4,0,.5,.3,.3,.6l-1.7,2.6c-.2,.3-.7,.6-1,.6L40.2,101.1z M25.1,110.3c-.4,0-.5-.2-.3-.5l2.1-2.7c.2-.3.7-.5,1.1-.5l45.6,0c.4,0,.6,.3,.5,.6l-.8,2.4c-.1,.4-.5,.6-.9,.6L25.1,110.3z M49.3,119.5c-.4,0-.5-.3-.3-.6l1.4-2.5c.2-.3,.6-.6,1-.6l20,0c.4,0,.6,.3,.6,.7l-.2,2.4c0,.4-.4,.7-.7,.7L49.3,119.5z M153.1,99.3c-6.3,1.6-10.6,2.8-16.8,4.4c-1.5,.4-1.6,.5-2.9-1c-1.5-1.7-2.6-2.8-4.7-3.8c-6.3-3.1-12.4-2.2-18.1,1.5c-6.8,4.4-10.3,10.9-10.2,19c.1,8,5.6,14.6,13.5,15.7c6.8,.9,12.5-1.5,17-6.6c.9-1.1,1.7-2.3,2.7-3.7c-3.6,0-8.1,0-19.3,0c-2.1,0-2.6-1.3-1.9-3c1.3-3.1,3.7-8.3,5.1-10.9c.3-.6,1-1.6,2.5-1.6c5.1,0,23.9,0,36.4,0c-.2,2.7-.2,5.4-.6,8.1c-1.1,7.2-3.8,13.8-8.2,19.6c-7.2,9.5-16.6,15.4-28.5,17c-9.8,1.3-18.9-.6-26.9-6.6c-7.4-5.6-11.6-13-12.7-22.2c-1.3-10.9,1.9-20.7,8.5-29.3c7.1-9.3,16.5-15.2,28-17.3c9.4-1.7,18.4-.6,26.5,4.9c5.3,3.5,9.1,8.3,11.6,14.1c.6,.9.2,1.4-1,1.7zM186.2,154.6c-9.1-.2-17.4-2.8-24.4-8.8c-5.9-5.1-9.6-11.6-10.8-19.3c-1.8-11.3,1.3-21.3,8.1-30.2c7.3-9.6,16.1-14.6,28-16.7c10.2-1.8,19.8-.8,28.5,5.1c7.9,5.4,12.8,12.7,14.1,22.3c1.7,13.5-2.2,24.5-11.5,33.9c-6.6,6.7-14.7,10.9-24,12.8c-2.7,.5-5.4,.6-8,.9zm23.8-40.4c-.1-1.3-.1-2.3-.3-3.3c-1.8-9.9-10.9-15.5-20.4-13.3c-9.3,2.1-15.3,8-17.5,17.4c-1.8,7.8,2,15.7,9.2,18.9c5.5,2.4,11,2.1,16.3-.6c7.9-4.1,12.2-10.5,12.7-19.1z"
                 />
               </svg>
-            </a>
+            </Link>
 
             {/* Item */}
-            <a href="https://keploy.io/docs/quickstart/samples-django/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
+            <Link href="https://keploy.io/docs/quickstart/samples-django/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="200"
@@ -659,10 +660,10 @@ export default function Language() {
                   fill="url(#c)"
                 />
               </svg>
-            </a>
+            </Link>
 
             {/* Item */}
-            <a href="https://keploy.io/docs/quickstart/samples-csharp/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
+            <Link href="https://keploy.io/docs/quickstart/samples-csharp/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
               <Image
                 src="/images/frameworks/csharp.svg"
                 alt="C# Logo"
@@ -670,10 +671,10 @@ export default function Language() {
                 height={80}
                 className="mb-2"
               />
-            </a>
+            </Link>
 
             {/* Item */}
-            <a href="https://keploy.io/docs/quickstart/samples-rust/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
+            <Link href="https://keploy.io/docs/quickstart/samples-rust/" className="flex items-center justify-center col-span-2 py-2 transition-transform hover:scale-110 md:col-auto">
               <Image
                 src="/images/frameworks/rust.svg"
                 alt="C# Logo"
@@ -681,7 +682,7 @@ export default function Language() {
                 height={80}
                 className="mb-5"
               />
-            </a>
+            </Link>
           </div>
           {/* Testimonials */}
           {/* <div className="max-w-3xl mx-auto mt-20 " data-aos="zoom-y-out">


### PR DESCRIPTION
Addresses [Issue #2090](https://github.com/keploy/keploy/issues/2090).

Makes the language icons on the home page clickable, redirects to the respective language's samples page. 

Current Behaviour:
![image](https://github.com/user-attachments/assets/16174ca9-dfcd-4635-a582-3f26df4aabb2)

Updated Behaviour:
![image](https://github.com/user-attachments/assets/d206d0a5-91a4-450d-8fd3-5102611a9dc4)
