### PR TITLE
added FAQs to Keploy's /unit-test-generator route

### DIFF
--- a/components/utils/unit-test-generator.tsx
+++ b/components/utils/unit-test-generator.tsx
@@ -89,6 +89,10 @@ export const featuresData = [
     {
       title: "How does Keploy generate coverage reports?",
       answer:"Keploy generates detailed Cobertura format reports, offering insights into test effectiveness and code quality."
+    },
+    {
+      title: "Does Keploy send your private data to any cloud server for test generation?",
+      answer: "No, Keploy does not send any user code to remote systems, except when using the unit test generation feature. When using the UT gen feature, only the source code and the unit test code will be sent to the Large Language Model (LLM) you are using. By default, Keploy uses - litellm to support vast number of LLM backends. Yes, if your organization has its own LLM(a private one), you can use it with Keploy. This ensures that data is not sent to any external systems.",
     }
   ]
 

--- a/components/utils/unit-test-generator.tsx
+++ b/components/utils/unit-test-generator.tsx
@@ -73,6 +73,10 @@ export const featuresData = [
         "Keploy's UTG automates the creation of unit tests based on code semantics, enhancing test coverage and reliability.",
     },
     {
+      title: "Does Keploy send your private data to any cloud server for test generation?",
+      answer: "No, Keploy does not send any user code to remote systems, except when using the unit test generation feature. When using the UT gen feature, only the source code and the unit test code will be sent to the Large Language Model (LLM) you are using. By default, Keploy uses - litellm to support vast number of LLM backends. Yes, if your organization has its own LLM(a private one), you can use it with Keploy. This ensures that data is not sent to any external systems.",
+    },
+    {
       title: "Can Keploy handle large codebases efficiently?",
       answer:
         "Yes, Keploy is designed to handle large codebases efficiently, though processing time may vary based on project size and complexity.",
@@ -90,10 +94,6 @@ export const featuresData = [
       title: "How does Keploy generate coverage reports?",
       answer:"Keploy generates detailed Cobertura format reports, offering insights into test effectiveness and code quality."
     },
-    {
-      title: "Does Keploy send your private data to any cloud server for test generation?",
-      answer: "No, Keploy does not send any user code to remote systems, except when using the unit test generation feature. When using the UT gen feature, only the source code and the unit test code will be sent to the Large Language Model (LLM) you are using. By default, Keploy uses - litellm to support vast number of LLM backends. Yes, if your organization has its own LLM(a private one), you can use it with Keploy. This ensures that data is not sent to any external systems.",
-    }
   ]
 
   


### PR DESCRIPTION
# About

Fixes - https://github.com/keploy/keploy/issues/2095

This PR adds a new FAQ to the `/unit-test-generator` route.