### PR TITLE
fix: update the Link Format of vscode extension

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -94,7 +94,7 @@ export default function Hero() {
                   {/* Wrapping Link with NeonButton */}
                     <Link
                       className="btn text-secondary-300 bg-primary-300 hover:text-gradient-500 w-full sm:w-auto sm:mb-0"
-                      href="vscode://Keploy.keployio/keploy.handleUri"
+                      href="vscode:extension/Keploy.keployio" target="_blank"
                     >
                       Try VS Code Extension
                     </Link>

--- a/components/ui/banner.tsx
+++ b/components/ui/banner.tsx
@@ -41,7 +41,7 @@ const Banner = () => {
       {/* Action buttons and close button */}
 <div className="flex flex-row sm:flex-row sm:items-center justify-center gap-1 sm:gap-3 lg:gap-4 ">
   <a
-    href="https://marketplace.visualstudio.com/items?itemName=Keploy.keployio"
+    href="vscode:extension/Keploy.keployio"
     target="_blank"
     rel="noopener noreferrer"
     className="bg-primary-400 hover:bg-primary-500 text-neutral-100 font-inter rounded px-2 sm:px-4 lg:px-6 py-2 lg:py-2 text-xs sm:text-sm lg:text-base text-center transition-all duration-200 shadow-md whitespace-nowrap"


### PR DESCRIPTION
Replace the extension url and use the vscode:extension protocol instead of vscode://