### PR TITLE
Replace Twitter Icon with X Icon

### DIFF
--- a/components/community.tsx
+++ b/components/community.tsx
@@ -3,7 +3,7 @@ import "./community.css";
 import Image from "next/image";
 import CommunityBunny from "@/public/images/community-bunny.png";
 import GithubSvg from "@/public/images/social/github.svg";
-import TwitterSvg from "@/public/images/social/twitter.svg";
+import TwitterSvg from "@/public/images/x-twitter.svg";
 import SlackSvg from "@/public/images/social/slack.svg";
 import YoutubeSvg from "@/public/images/social/youtube.svg";
 import LinkedinSvg from "@/public/images/social/linkedin.svg";
@@ -79,9 +79,9 @@ function SocialLinkCard({
 export default function Community() {
   const cardsData: CardData[] = [
     {
-      link: "https://twitter.com/Keployio",
+      link: "https://x.com/Keployio",
       svgIcon: TwitterSvg,
-      platformName: "Twitter",
+      platformName: "X",
       description: "Let's talk about regression testing!",
     },
     {


### PR DESCRIPTION
Resolves [#2482](https://github.com/keploy/keploy/issues/2482)

## Description:
<img width="1326" alt="Screenshot 2024-12-27 at 3 53 58 PM" src="https://github.com/user-attachments/assets/ddb06c8b-9ef5-4407-843f-8e55b8ccfc22" />
This PR addresses the issue of the outdated Twitter icon still being displayed on the website. Following Twitter’s rebranding to X, we are replacing the old Twitter icon with the new X icon. The links associated with the icon will also be updated to the new X platform URL.

## Changes Made:
<img width="1326" alt="Screenshot 2024-12-27 at 4 28 07 PM" src="https://github.com/user-attachments/assets/18bca2ae-695d-4048-94a6-06591a2161f3" />

- Replaced the old Twitter icon with the new X icon on the website.
- Updated the associated link to point to the new X platform URL ([https://x.com/yourprofile](https://x.com/yourprofile)).

## Steps to Test:
1. Go to the website [keploy.io].
2. Verify that the Twitter icon has been replaced with the X icon.
3. Ensure the icon links to the new X platform URL.
