### PR TITLE
Adding cursor pointer on 'Join Wailist' button hover

### DIFF
--- a/components/pillar-page/block.tsx
+++ b/components/pillar-page/block.tsx
@@ -70,7 +70,7 @@ export default function ProblemBlocks(props: {
               }}
              className="flex justify-center md:justify-center gap-4 mt-8">
               <a
-                className="btn text-secondary-300 bg-primary-300 hover:text-white"
+                className="btn text-secondary-300 bg-primary-300 hover:text-white cursor-pointer"
               > 
                 {props.btnText}
               </a>


### PR DESCRIPTION
Whenever the cursor is hovered over the "Join Waitlist" buttons present in multiple pages like - Test Data Generation page, Test Case Generation page, Unit Test Generation page, Code Coverage page..., the cursor does not turn into a cursor-pointer.

This tiny PR fixes the above bug

![ss1](https://github.com/user-attachments/assets/f0d7396b-4abf-4a95-bbbc-d4770626ce8a)

Signed-off-by: Ahmed Gulab Khan gulabkhan.jalozai@gmail.com